### PR TITLE
Added the ability to switch the inclusion of the correlation ID in th…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Build with Maven
         run: mvn clean install -B
 
+      - name: Mutation testing
+        run: mvn org.pitest:pitest-maven:mutationCoverage -B
+
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,9 @@
         <slf4j.version>1.7.36</slf4j.version>
         <spring.version>5.3.23</spring.version>
 
+        <!-- Test dependency versions -->
+        <spt-development-test>2.0.9</spt-development-test>
+
         <!-- Test dependency versions, matched to Spring Boot -->
         <hamcrest.version>2.2</hamcrest.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
@@ -132,6 +135,18 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>com.spt-development</groupId>
+            <artifactId>spt-development-test</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+            <version>${spt-development-test}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>${hamcrest.version}</version>
@@ -146,6 +161,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+            <!-- Version defined in junit bom, imported in dependencyManagement section -->
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
             <!-- Version defined in junit bom, imported in dependencyManagement section -->
         </dependency>

--- a/src/main/java/com/spt/development/logging/spring/JmsListenerLogger.java
+++ b/src/main/java/com/spt/development/logging/spring/JmsListenerLogger.java
@@ -1,6 +1,5 @@
 package com.spt.development.logging.spring;
 
-import com.spt.development.cid.CorrelationId;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -16,7 +15,25 @@ import static com.spt.development.logging.spring.LoggerUtil.formatArgs;
  */
 @Aspect
 @Order(1)
-public class JmsListenerLogger {
+public class JmsListenerLogger extends LoggerAspect {
+
+    /**
+     * Creates a new instance of the logger aspect. The log statements added by the aspect will include the current
+     * correlation ID; see {@link JmsListenerLogger#JmsListenerLogger(boolean)} to disable this behaviour.
+     */
+    public JmsListenerLogger() {
+        this(true);
+    }
+
+    /**
+     * Creates a new instance of the logger aspect.
+     *
+     * @param includeCorrelationIdInLogs a flag to determine whether the correlation ID should be explicitly included
+     *                                   in the log statements added by the aspect.
+     */
+    public JmsListenerLogger(final boolean includeCorrelationIdInLogs) {
+        super(includeCorrelationIdInLogs);
+    }
 
     /**
      * Outputs INFO level logging when a public method annotated with the
@@ -43,9 +60,8 @@ public class JmsListenerLogger {
         final Logger log = LoggerFactory.getLogger(signature.getDeclaringType());
 
         if (log.isInfoEnabled()) {
-
-            log.info("[{}] {}.{}({})", CorrelationId.get(), point.getTarget().getClass().getSimpleName(),
-                    point.getSignature().getName(), formatArgs(signature.getMethod().getParameterAnnotations(), point.getArgs()));
+            info(log, "{}.{}({})", point.getTarget().getClass().getSimpleName(), point.getSignature().getName(),
+                    formatArgs(signature.getMethod().getParameterAnnotations(), point.getArgs()));
         }
         return proceed(point, log);
     }
@@ -53,8 +69,7 @@ public class JmsListenerLogger {
     private Object proceed(ProceedingJoinPoint point, Logger log) throws Throwable {
         final Object result = point.proceed();
 
-        log.info("[{}] {}.{} - complete", CorrelationId.get(), point.getTarget().getClass().getSimpleName(),
-                point.getSignature().getName());
+        info(log, "{}.{} - complete", point.getTarget().getClass().getSimpleName(), point.getSignature().getName());
 
         return result;
     }

--- a/src/main/java/com/spt/development/logging/spring/LoggerAspect.java
+++ b/src/main/java/com/spt/development/logging/spring/LoggerAspect.java
@@ -1,0 +1,47 @@
+package com.spt.development.logging.spring;
+
+import com.spt.development.cid.CorrelationId;
+import org.slf4j.Logger;
+
+import java.util.function.BiConsumer;
+
+abstract class LoggerAspect {
+    private final boolean includeCorrelationIdInLogs;
+
+    LoggerAspect(final boolean includeCorrelationIdInLogs) {
+        this.includeCorrelationIdInLogs = includeCorrelationIdInLogs;
+    }
+
+    void trace(Logger logger, String format, Object... arguments) {
+        log(logger::trace, format, arguments);
+    }
+
+    void debug(Logger logger, String format, Object... arguments) {
+        log(logger::debug, format, arguments);
+    }
+
+    void info(Logger logger, String format, Object... arguments) {
+        log(logger::info, format, arguments);
+    }
+
+    void error(Logger logger, String format, Object... arguments) {
+        log(logger::error, format, arguments);
+    }
+
+    private void log(BiConsumer<String, Object[]> log, String format, Object[] arguments) {
+        if (includeCorrelationIdInLogs) {
+            log.accept("[{}] " + format, addCorrelationIdToArguments(arguments));
+            return;
+        }
+        log.accept(format, arguments);
+    }
+
+    private Object[] addCorrelationIdToArguments(Object[] arguments) {
+        final Object[] newArguments = new Object[arguments.length + 1];
+        newArguments[0] = CorrelationId.get();
+
+        System.arraycopy(arguments, 0, newArguments, 1, arguments.length);
+
+        return newArguments;
+    }
+}

--- a/src/main/java/com/spt/development/logging/spring/RepositoryLogger.java
+++ b/src/main/java/com/spt/development/logging/spring/RepositoryLogger.java
@@ -1,6 +1,5 @@
 package com.spt.development.logging.spring;
 
-import com.spt.development.cid.CorrelationId;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -15,7 +14,25 @@ import static com.spt.development.logging.spring.LoggerUtil.formatArgs;
  * annotation.
  */
 @Aspect
-public class RepositoryLogger {
+public class RepositoryLogger extends LoggerAspect {
+
+    /**
+     * Creates a new instance of the logger aspect. The log statements added by the aspect will include the current
+     * correlation ID; see {@link RepositoryLogger#RepositoryLogger(boolean)} to disable this behaviour.
+     */
+    public RepositoryLogger() {
+        this(true);
+    }
+
+    /**
+     * Creates a new instance of the logger aspect.
+     *
+     * @param includeCorrelationIdInLogs a flag to determine whether the correlation ID should be explicitly included
+     *                                   in the log statements added by the aspect.
+     */
+    public RepositoryLogger(final boolean includeCorrelationIdInLogs) {
+        super(includeCorrelationIdInLogs);
+    }
 
     /**
      * Outputs DEBUG level logging when a public method belonging to a class, annotated with the
@@ -43,8 +60,8 @@ public class RepositoryLogger {
         final Logger log = LoggerFactory.getLogger(signature.getDeclaringType());
 
         if (log.isDebugEnabled()) {
-            log.debug("[{}] {}.{}({})", CorrelationId.get(), point.getTarget().getClass().getSimpleName(),
-                    point.getSignature().getName(), formatArgs(signature.getMethod().getParameterAnnotations(), point.getArgs()));
+            debug(log, "{}.{}({})", point.getTarget().getClass().getSimpleName(), point.getSignature().getName(),
+                    formatArgs(signature.getMethod().getParameterAnnotations(), point.getArgs()));
         }
         return proceed(point, log);
     }
@@ -56,14 +73,12 @@ public class RepositoryLogger {
             final MethodSignature methodSignature = (MethodSignature)point.getSignature();
 
             if (!methodSignature.getReturnType().equals(void.class)) {
-                log.trace("[{}] {}.{} Returned: {}", CorrelationId.get(), point.getTarget().getClass().getSimpleName(),
-                        methodSignature.getName(), result);
+                trace(log, "{}.{} Returned: {}", point.getTarget().getClass().getSimpleName(), methodSignature.getName(), result);
 
                 return result;
             }
         }
-        log.debug("[{}] {}.{} - complete", CorrelationId.get(), point.getTarget().getClass().getSimpleName(),
-                point.getSignature().getName());
+        debug(log, "{}.{} - complete", point.getTarget().getClass().getSimpleName(), point.getSignature().getName());
 
         return result;
     }

--- a/src/main/java/com/spt/development/logging/spring/ServiceLogger.java
+++ b/src/main/java/com/spt/development/logging/spring/ServiceLogger.java
@@ -1,6 +1,5 @@
 package com.spt.development.logging.spring;
 
-import com.spt.development.cid.CorrelationId;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -15,7 +14,25 @@ import static com.spt.development.logging.spring.LoggerUtil.formatArgs;
  * annotation.
  */
 @Aspect
-public class ServiceLogger {
+public class ServiceLogger extends LoggerAspect {
+
+    /**
+     * Creates a new instance of the logger aspect. The log statements added by the aspect will include the current
+     * correlation ID; see {@link ServiceLogger#ServiceLogger(boolean)} to disable this behaviour.
+     */
+    public ServiceLogger() {
+        this(true);
+    }
+
+    /**
+     * Creates a new instance of the logger aspect.
+     *
+     * @param includeCorrelationIdInLogs a flag to determine whether the correlation ID should be explicitly included
+     *                                   in the log statements added by the aspect.
+     */
+    public ServiceLogger(final boolean includeCorrelationIdInLogs) {
+        super(includeCorrelationIdInLogs);
+    }
 
     /**
      * Outputs DEBUG level logging when a public method belonging to a class, annotated with the
@@ -43,8 +60,8 @@ public class ServiceLogger {
         final Logger log = LoggerFactory.getLogger(signature.getDeclaringType());
 
         if (log.isDebugEnabled()) {
-            log.debug("[{}] {}.{}({})", CorrelationId.get(), point.getTarget().getClass().getSimpleName(),
-                    point.getSignature().getName(), formatArgs(signature.getMethod().getParameterAnnotations(), point.getArgs()));
+            debug(log, "{}.{}({})", point.getTarget().getClass().getSimpleName(), point.getSignature().getName(),
+                    formatArgs(signature.getMethod().getParameterAnnotations(), point.getArgs()));
         }
         return proceed(point, log);
     }
@@ -56,14 +73,12 @@ public class ServiceLogger {
             final MethodSignature methodSignature = (MethodSignature)point.getSignature();
 
             if (!methodSignature.getReturnType().equals(void.class)) {
-                log.trace("[{}] {}.{} Returned: {}", CorrelationId.get(), point.getTarget().getClass().getSimpleName(),
-                        methodSignature.getName(), result);
+                trace(log, "{}.{} Returned: {}", point.getTarget().getClass().getSimpleName(), methodSignature.getName(), result);
 
                 return result;
             }
         }
-        log.debug("[{}] {}.{} - complete", CorrelationId.get(), point.getTarget().getClass().getSimpleName(),
-                point.getSignature().getName());
+        debug(log, "{}.{} - complete", point.getTarget().getClass().getSimpleName(), point.getSignature().getName());
 
         return result;
     }

--- a/src/test/java/com/spt/development/logging/spring/JmsListenerLoggerTest.java
+++ b/src/test/java/com/spt/development/logging/spring/JmsListenerLoggerTest.java
@@ -1,25 +1,95 @@
 package com.spt.development.logging.spring;
 
+import com.spt.development.cid.CorrelationId;
 import com.spt.development.logging.NoLogging;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
+import static com.spt.development.test.LogbackUtil.verifyLogging;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 class JmsListenerLoggerTest {
     private interface TestData {
+        String CORRELATION_ID = "f3867dd5-b137-4c05-8816-69fd262024b7";
         String RESULT = "Success!";
         String METHOD = "test";
         String ARG1 = "TestArg";
         String ARG2 = "TestArg2";
     }
 
+    @BeforeEach
+    void setUp() {
+        CorrelationId.set(TestData.CORRELATION_ID);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void log_validJoinPoint_shouldReturnJoinPointResult(boolean includeCorrelationIdInLogs) throws Throwable {
+        final Object result = createLogger(includeCorrelationIdInLogs).log(createJoinPoint());
+
+        assertThat(result, is(TestData.RESULT));
+    }
+
     @Test
-    void log_validJoinPoint_shouldReturnJoinPointResult() throws Throwable {
+    void log_validJoinPoint_shouldLogStartAndEndOfMethodWithoutCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(false).log(createJoinPoint());
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test - complete"));
+                }
+        );
+    }
+
+    @Test
+    void log_validJoinPoint_shouldLogStartAndEndOfMethodWithCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(true).log(createJoinPoint());
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test - complete"));
+                }
+        );
+    }
+
+    private ProceedingJoinPoint createJoinPoint() throws Throwable {
         final ProceedingJoinPoint joinPoint = Mockito.mock(ProceedingJoinPoint.class);
         final MethodSignature methodSignature = Mockito.mock(MethodSignature.class);
 
@@ -32,13 +102,11 @@ class JmsListenerLoggerTest {
         when(methodSignature.getName()).thenReturn(TestData.METHOD);
         when(methodSignature.getMethod()).thenReturn(TestTarget.class.getMethod(TestData.METHOD, String.class, String.class));
 
-        final Object result = createLogger().log(joinPoint);
-
-        assertThat(result, is(TestData.RESULT));
+        return joinPoint;
     }
 
-    private JmsListenerLogger createLogger() {
-        return new JmsListenerLogger();
+    private JmsListenerLogger createLogger(boolean includeCorrelationIdInLogs) {
+        return includeCorrelationIdInLogs ? new JmsListenerLogger() : new JmsListenerLogger(false);
     }
 
     private static class TestTarget {

--- a/src/test/java/com/spt/development/logging/spring/RepositoryLoggerTest.java
+++ b/src/test/java/com/spt/development/logging/spring/RepositoryLoggerTest.java
@@ -1,65 +1,183 @@
 package com.spt.development.logging.spring;
 
+import ch.qos.logback.classic.Level;
+import com.spt.development.cid.CorrelationId;
 import com.spt.development.logging.NoLogging;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
+import static com.spt.development.test.LogbackUtil.verifyLogging;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 class RepositoryLoggerTest {
     private interface TestData {
+        String CORRELATION_ID = "2f0c045f-7547-438c-8496-700126b4d1f8";
         String RESULT = "Success!";
         String METHOD = "test";
         String ARG1 = "TestArg";
         String ARG2 = "TestArg2";
     }
 
-    @Test
-    void log_joinPointWithReturnValue_shouldReturnJoinPointResult() throws Throwable {
-        final ProceedingJoinPoint joinPoint = Mockito.mock(ProceedingJoinPoint.class);
-        final MethodSignature methodSignature = Mockito.mock(MethodSignature.class);
+    @BeforeEach
+    void setUp() {
+        CorrelationId.set(TestData.CORRELATION_ID);
+    }
 
-        when(joinPoint.getSignature()).thenReturn(methodSignature);
-        when(joinPoint.proceed()).thenReturn(TestData.RESULT);
-        when(joinPoint.getTarget()).thenReturn(new TestTarget());
-        when(joinPoint.getArgs()).thenReturn(new Object[] { TestData.ARG1, TestData.ARG2 });
-
-        when(methodSignature.getDeclaringType()).thenReturn(TestTarget.class);
-        when(methodSignature.getName()).thenReturn(TestData.METHOD);
-        when(methodSignature.getMethod()).thenReturn(TestTarget.class.getMethod(TestData.METHOD, String.class, String.class));
-        when(methodSignature.getReturnType()).thenReturn(String.class);
-
-        final Object result = createLogger().log(joinPoint);
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void log_joinPointWithReturnValue_shouldReturnJoinPointResult(boolean includeCorrelationIdInLogs) throws Throwable {
+        final Object result = createLogger(includeCorrelationIdInLogs).log(createJoinPoint(String.class, TestData.RESULT));
 
         assertThat(result, is(TestData.RESULT));
     }
 
     @Test
-    void log_joinPointWithVoidReturnType_shouldReturnNull() throws Throwable {
+    void log_joinPointWithReturnValue_shouldLogStartAndEndOfMethodWithoutCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(false).log(createJoinPoint(String.class, TestData.RESULT));
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(0).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.TRACE));
+                    assertThat(logs.get(1).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test Returned: " + TestData.RESULT));
+                }
+        );
+    }
+
+    @Test
+    void log_joinPointWithReturnValue_shouldLogStartAndEndOfMethodWithCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(true).log(createJoinPoint(String.class, TestData.RESULT));
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(0).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.TRACE));
+                    assertThat(logs.get(1).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test Returned: " + TestData.RESULT));
+                }
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void log_joinPointWithVoidReturnType_shouldReturnNull(boolean includeCorrelationIdInLogs) throws Throwable {
+        final Object result = createLogger(includeCorrelationIdInLogs).log(createJoinPoint(void.class));
+
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    void log_joinPointWithVoidReturnValue_shouldLogStartAndEndOfMethodWithoutCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(false).log(createJoinPoint(void.class));
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(0).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(1).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test - complete"));
+                }
+        );
+    }
+
+    @Test
+    void log_joinPointWithVoidReturnValue_shouldLogStartAndEndOfMethodWithCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(true).log(createJoinPoint(void.class));
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(0).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(1).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test - complete"));
+                }
+        );
+    }
+
+    private ProceedingJoinPoint createJoinPoint(Class<Void> methodReturnType) throws Throwable {
+        return createJoinPoint(methodReturnType, null);
+    }
+
+    private <T> ProceedingJoinPoint createJoinPoint(Class<T> methodReturnType, T returnValue) throws Throwable {
         final ProceedingJoinPoint joinPoint = Mockito.mock(ProceedingJoinPoint.class);
         final MethodSignature methodSignature = Mockito.mock(MethodSignature.class);
 
         when(joinPoint.getSignature()).thenReturn(methodSignature);
+        when(joinPoint.proceed()).thenReturn(returnValue);
         when(joinPoint.getTarget()).thenReturn(new TestTarget());
         when(joinPoint.getArgs()).thenReturn(new Object[] { TestData.ARG1, TestData.ARG2 });
 
         when(methodSignature.getDeclaringType()).thenReturn(TestTarget.class);
         when(methodSignature.getName()).thenReturn(TestData.METHOD);
         when(methodSignature.getMethod()).thenReturn(TestTarget.class.getMethod(TestData.METHOD, String.class, String.class));
-        when(methodSignature.getReturnType()).thenReturn(void.class);
+        when(methodSignature.getReturnType()).thenReturn(methodReturnType);
 
-        final Object result = createLogger().log(joinPoint);
-
-        assertThat(result, is(nullValue()));
+        return joinPoint;
     }
 
-    private RepositoryLogger createLogger() {
-        return new RepositoryLogger();
+    private RepositoryLogger createLogger(boolean includeCorrelationIdInLogs) {
+        return includeCorrelationIdInLogs ? new RepositoryLogger() : new RepositoryLogger(false);
     }
 
     private static class TestTarget {

--- a/src/test/java/com/spt/development/logging/spring/RestControllerLoggerTest.java
+++ b/src/test/java/com/spt/development/logging/spring/RestControllerLoggerTest.java
@@ -1,150 +1,497 @@
 package com.spt.development.logging.spring;
 
+import ch.qos.logback.classic.Level;
+import com.spt.development.cid.CorrelationId;
 import com.spt.development.logging.NoLogging;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 
+import static com.spt.development.test.LogbackUtil.verifyLogging;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 class RestControllerLoggerTest {
     private interface TestData {
+        String CORRELATION_ID = "52d676d9-81f3-4167-a078-09a1c2ed9a01";
         String RESULT = "Success!";
         String METHOD = "test";
         String ARG1 = "TestArg";
         String ARG2 = "TestArg2";
     }
 
-    @Test
-    void log_joinPointWithReturnValue_shouldReturnJoinPointResult() throws Throwable {
-        final ProceedingJoinPoint joinPoint = Mockito.mock(ProceedingJoinPoint.class);
-        final MethodSignature methodSignature = Mockito.mock(MethodSignature.class);
+    @BeforeEach
+    void setUp() {
+        CorrelationId.set(TestData.CORRELATION_ID);
+    }
 
-        when(joinPoint.getSignature()).thenReturn(methodSignature);
-        when(joinPoint.proceed()).thenReturn(TestData.RESULT);
-        when(joinPoint.getTarget()).thenReturn(new TestTarget());
-        when(joinPoint.getArgs()).thenReturn(new Object[] { TestData.ARG1, TestData.ARG2 });
-
-        when(methodSignature.getDeclaringType()).thenReturn(TestTarget.class);
-        when(methodSignature.getName()).thenReturn(TestData.METHOD);
-        when(methodSignature.getMethod()).thenReturn(TestTarget.class.getMethod(TestData.METHOD, String.class, String.class));
-        when(methodSignature.getReturnType()).thenReturn(String.class);
-
-        final Object result = createLogger().log(joinPoint);
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void log_joinPointWithReturnValue_shouldReturnJoinPointResult(boolean includeCorrelationIdInLogs) throws Throwable {
+        final Object result = createLogger(includeCorrelationIdInLogs).log(createJoinPoint(String.class, TestData.RESULT));
 
         assertThat(result, is(TestData.RESULT));
     }
 
     @Test
-    void log_joinPointWithVoidReturnType_shouldReturnNull() throws Throwable {
-        final ProceedingJoinPoint joinPoint = Mockito.mock(ProceedingJoinPoint.class);
-        final MethodSignature methodSignature = Mockito.mock(MethodSignature.class);
+    void log_joinPointWithReturnValue_shouldLogStartAndEndOfMethodWithoutCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(false).log(createJoinPoint(String.class, TestData.RESULT));
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
 
-        when(joinPoint.getSignature()).thenReturn(methodSignature);
-        when(joinPoint.getTarget()).thenReturn(new TestTarget());
-        when(joinPoint.getArgs()).thenReturn(new Object[] { TestData.ARG1, TestData.ARG2 });
+                    assertThat(logs.get(0).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(0).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
 
-        when(methodSignature.getDeclaringType()).thenReturn(TestTarget.class);
-        when(methodSignature.getName()).thenReturn(TestData.METHOD);
-        when(methodSignature.getMethod()).thenReturn(TestTarget.class.getMethod(TestData.METHOD, String.class, String.class));
-        when(methodSignature.getReturnType()).thenReturn(void.class);
+                    assertThat(logs.get(1).getLevel(), is(Level.TRACE));
+                    assertThat(logs.get(1).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test Returned: " + TestData.RESULT));
+                }
+        );
+    }
 
-        final Object result = createLogger().log(joinPoint);
+    @Test
+    void log_joinPointWithReturnValue_shouldLogStartAndEndOfMethodWithCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(true).log(createJoinPoint(String.class, TestData.RESULT));
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(0).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.TRACE));
+                    assertThat(logs.get(1).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test Returned: " + TestData.RESULT));
+                }
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void log_joinPointWithVoidReturnType_shouldReturnNull(boolean includeCorrelationIdInLogs) throws Throwable {
+        final Object result = createLogger(includeCorrelationIdInLogs).log(createJoinPoint(void.class));
 
         assertThat(result, is(nullValue()));
     }
 
     @Test
-    void log_proceedThrowsUnexepectedException_shouldThrowException() throws Throwable {
-        final ProceedingJoinPoint joinPoint = Mockito.mock(ProceedingJoinPoint.class);
-        final MethodSignature methodSignature = Mockito.mock(MethodSignature.class);
+    void log_joinPointWithVoidReturnValue_shouldLogStartAndEndOfMethodWithoutCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(false).log(createJoinPoint(void.class));
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
 
-        when(joinPoint.getSignature()).thenReturn(methodSignature);
-        when(joinPoint.getTarget()).thenReturn(new TestTarget());
-        when(joinPoint.getArgs()).thenReturn(new Object[] { TestData.ARG1, TestData.ARG2 });
-        when(joinPoint.proceed()).thenThrow(new Exception("test"));
+                    assertThat(logs.get(0).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(0).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
 
-        when(methodSignature.getDeclaringType()).thenReturn(TestTarget.class);
-        when(methodSignature.getName()).thenReturn(TestData.METHOD);
-        when(methodSignature.getMethod()).thenReturn(TestTarget.class.getMethod(TestData.METHOD, String.class, String.class));
-        when(methodSignature.getReturnType()).thenReturn(void.class);
+                    assertThat(logs.get(1).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(1).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test - complete"));
+                }
+        );
+    }
 
-        final RestControllerLogger target = createLogger();
+    @Test
+    void log_joinPointWithVoidReturnValue_shouldLogStartAndEndOfMethodWithCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(true).log(createJoinPoint(void.class));
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(0).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(1).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test - complete"));
+                }
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void log_proceedThrowsUnexpectedException_shouldThrowException(boolean includeCorrelationIdInLogs) throws Throwable {
+        final ProceedingJoinPoint joinPoint = createJoinPoint(new Exception("test"));
+        final RestControllerLogger target = createLogger(includeCorrelationIdInLogs);
 
         assertThrows(Exception.class, () -> target.log(joinPoint));
     }
 
     @Test
-    void log_proceedThrowsHttpServerErrorException_shouldThrowException() throws Throwable {
-        final ProceedingJoinPoint joinPoint = Mockito.mock(ProceedingJoinPoint.class);
-        final MethodSignature methodSignature = Mockito.mock(MethodSignature.class);
+    void log_proceedThrowsUnexpectedException_shouldLogExceptionAsErrorWithoutCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(false).log(createJoinPoint(new Exception("test")));
+                    } catch (Throwable t) {
+                        // Expected exception
+                        return null;
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
 
-        when(joinPoint.getSignature()).thenReturn(methodSignature);
-        when(joinPoint.getTarget()).thenReturn(new TestTarget());
-        when(joinPoint.getArgs()).thenReturn(new Object[] { TestData.ARG1, TestData.ARG2 });
-        when(joinPoint.proceed()).thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+                    assertThat(logs.get(0).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(0).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
 
-        when(methodSignature.getDeclaringType()).thenReturn(TestTarget.class);
-        when(methodSignature.getName()).thenReturn(TestData.METHOD);
-        when(methodSignature.getMethod()).thenReturn(TestTarget.class.getMethod(TestData.METHOD, String.class, String.class));
-        when(methodSignature.getReturnType()).thenReturn(void.class);
+                    assertThat(logs.get(1).getLevel(), is(Level.ERROR));
+                    assertThat(logs.get(1).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test threw exception:"));
+                    assertThat(logs.get(1).getThrowableProxy(), is(notNullValue()));
+                    assertThat(logs.get(1).getThrowableProxy().getClassName(), is("java.lang.Exception"));
+                    assertThat(logs.get(1).getThrowableProxy().getMessage(), is("test"));
+                }
+        );
+    }
 
-        final RestControllerLogger target = createLogger();
+    @Test
+    void log_proceedThrowsUnexpectedException_shouldLogExceptionAsErrorWithCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(true).log(createJoinPoint(new Exception("test")));
+                    } catch (Throwable t) {
+                        // Expected exception
+                        return null;
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(0).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.ERROR));
+                    assertThat(logs.get(1).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test threw exception:"));
+                    assertThat(logs.get(1).getThrowableProxy(), is(notNullValue()));
+                    assertThat(logs.get(1).getThrowableProxy().getClassName(), is("java.lang.Exception"));
+                    assertThat(logs.get(1).getThrowableProxy().getMessage(), is("test"));
+                }
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void log_proceedThrowsHttpServerErrorException_shouldThrowException(boolean includeCorrelationIdInLogs) throws Throwable {
+        final ProceedingJoinPoint joinPoint = createJoinPoint(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+        final RestControllerLogger target = createLogger(includeCorrelationIdInLogs);
 
         assertThrows(HttpServerErrorException.class, () -> target.log(joinPoint));
     }
 
     @Test
-    void log_proceedThrowsExceptionAnnotatedAsClientException_shouldThrowException() throws Throwable {
-        final ProceedingJoinPoint joinPoint = Mockito.mock(ProceedingJoinPoint.class);
-        final MethodSignature methodSignature = Mockito.mock(MethodSignature.class);
+    void log_proceedThrowsHttpServerErrorException_shouldLogExceptionAsErrorWithoutCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(false).log(createJoinPoint(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR)));
+                    } catch (Throwable t) {
+                        // Expected exception
+                        return null;
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
 
-        when(joinPoint.getSignature()).thenReturn(methodSignature);
-        when(joinPoint.getTarget()).thenReturn(new TestTarget());
-        when(joinPoint.getArgs()).thenReturn(new Object[] { TestData.ARG1, TestData.ARG2 });
-        when(joinPoint.proceed()).thenThrow(new DuplicateUserException("Test", new Exception()));
+                    assertThat(logs.get(0).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(0).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
 
-        when(methodSignature.getDeclaringType()).thenReturn(TestTarget.class);
-        when(methodSignature.getName()).thenReturn(TestData.METHOD);
-        when(methodSignature.getMethod()).thenReturn(TestTarget.class.getMethod(TestData.METHOD, String.class, String.class));
-        when(methodSignature.getReturnType()).thenReturn(void.class);
+                    assertThat(logs.get(1).getLevel(), is(Level.ERROR));
+                    assertThat(logs.get(1).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test threw exception:"));
+                    assertThat(logs.get(1).getThrowableProxy(), is(notNullValue()));
+                    assertThat(logs.get(1).getThrowableProxy().getClassName(), is("org.springframework.web.client.HttpServerErrorException"));
+                    assertThat(logs.get(1).getThrowableProxy().getMessage(), is("500 INTERNAL_SERVER_ERROR"));
+                }
+        );
+    }
 
-        final RestControllerLogger target = createLogger();
+    @Test
+    void log_proceedThrowsHttpServerErrorException_shouldLogExceptionAsErrorWithCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(true).log(createJoinPoint(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR)));
+                    } catch (Throwable t) {
+                        // Expected exception
+                        return null;
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(0).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.ERROR));
+                    assertThat(logs.get(1).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test threw exception:"));
+                    assertThat(logs.get(1).getThrowableProxy(), is(notNullValue()));
+                    assertThat(logs.get(1).getThrowableProxy().getClassName(), is("org.springframework.web.client.HttpServerErrorException"));
+                    assertThat(logs.get(1).getThrowableProxy().getMessage(), is("500 INTERNAL_SERVER_ERROR"));
+                }
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void log_proceedThrowsExceptionAnnotatedAsClientException_shouldThrowException(boolean includeCorrelationIdInLogs) throws Throwable {
+        final ProceedingJoinPoint joinPoint = createJoinPoint(new DuplicateUserException("Test", new Exception()));
+        final RestControllerLogger target = createLogger(includeCorrelationIdInLogs);
 
         assertThrows(DuplicateUserException.class, () -> target.log(joinPoint));
     }
 
     @Test
-    void log_proceedThrowsHttpClientErrorException_shouldThrowException() throws Throwable {
-        final ProceedingJoinPoint joinPoint = Mockito.mock(ProceedingJoinPoint.class);
-        final MethodSignature methodSignature = Mockito.mock(MethodSignature.class);
+    void log_proceedThrowsExceptionAnnotatedAsClientException_shouldLogExceptionAsInfoWithoutCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(false).log(createJoinPoint(new DuplicateUserException("Test", new Exception())));
+                    } catch (Throwable t) {
+                        // Expected exception
+                        return null;
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(3));
 
-        when(joinPoint.getSignature()).thenReturn(methodSignature);
-        when(joinPoint.getTarget()).thenReturn(new TestTarget());
-        when(joinPoint.getArgs()).thenReturn(new Object[] { TestData.ARG1, TestData.ARG2 });
-        when(joinPoint.proceed()).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+                    assertThat(logs.get(0).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(0).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
 
-        when(methodSignature.getDeclaringType()).thenReturn(TestTarget.class);
-        when(methodSignature.getName()).thenReturn(TestData.METHOD);
-        when(methodSignature.getMethod()).thenReturn(TestTarget.class.getMethod(TestData.METHOD, String.class, String.class));
-        when(methodSignature.getReturnType()).thenReturn(void.class);
+                    assertThat(logs.get(1).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(1).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test threw exception: com.spt.development.logging.spring.RestControllerLoggerTest.DuplicateUserException"));
 
-        final RestControllerLogger target = createLogger();
+                    assertThat(logs.get(2).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(2).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(2).getFormattedMessage(), containsString("Exception:"));
+                    assertThat(logs.get(2).getThrowableProxy(), is(notNullValue()));
+                    assertThat(logs.get(2).getThrowableProxy().getClassName(), is("com.spt.development.logging.spring.RestControllerLoggerTest$DuplicateUserException"));
+                    assertThat(logs.get(2).getThrowableProxy().getMessage(), is("Test"));
+                }
+        );
+    }
+
+    @Test
+    void log_proceedThrowsExceptionAnnotatedAsClientException_shouldLogExceptionAsDebugWithCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(true).log(createJoinPoint(new DuplicateUserException("Test", new Exception())));
+                    } catch (Throwable t) {
+                        // Expected exception
+                        return null;
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(3));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(0).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(1).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test threw exception: com.spt.development.logging.spring.RestControllerLoggerTest.DuplicateUserException"));
+
+                    assertThat(logs.get(2).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(2).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(2).getFormattedMessage(), containsString("Exception:"));
+                    assertThat(logs.get(2).getThrowableProxy(), is(notNullValue()));
+                    assertThat(logs.get(2).getThrowableProxy().getClassName(), is("com.spt.development.logging.spring.RestControllerLoggerTest$DuplicateUserException"));
+                    assertThat(logs.get(2).getThrowableProxy().getMessage(), is("Test"));
+                }
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void log_proceedThrowsHttpClientErrorException_shouldThrowException(boolean includeCorrelationIdInLogs) throws Throwable {
+        final ProceedingJoinPoint joinPoint = createJoinPoint(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+        final RestControllerLogger target = createLogger(includeCorrelationIdInLogs);
 
         assertThrows(HttpClientErrorException.class, () -> target.log(joinPoint));
     }
 
-    private RestControllerLogger createLogger() {
-        return new RestControllerLogger();
+    @Test
+    void log_proceedThrowsHttpClientErrorException_shouldLogExceptionAsInfoWithoutCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(false).log(createJoinPoint(new HttpClientErrorException(HttpStatus.BAD_REQUEST)));
+                    } catch (Throwable t) {
+                        // Expected exception
+                        return null;
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(3));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(0).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(1).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test threw exception: org.springframework.web.client.HttpClientErrorException"));
+
+                    assertThat(logs.get(2).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(2).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(2).getFormattedMessage(), containsString("Exception:"));
+                    assertThat(logs.get(2).getThrowableProxy(), is(notNullValue()));
+                    assertThat(logs.get(2).getThrowableProxy().getClassName(), is("org.springframework.web.client.HttpClientErrorException"));
+                    assertThat(logs.get(2).getThrowableProxy().getMessage(), is("400 BAD_REQUEST"));
+                }
+        );
+    }
+
+    @Test
+    void log_proceedThrowsHttpClientErrorException_shouldLogExceptionAsDebugWithCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(true).log(createJoinPoint(new HttpClientErrorException(HttpStatus.BAD_REQUEST)));
+                    } catch (Throwable t) {
+                        // Expected exception
+                        return null;
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(3));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(0).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.INFO));
+                    assertThat(logs.get(1).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test threw exception: org.springframework.web.client.HttpClientErrorException"));
+
+                    assertThat(logs.get(2).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(2).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(2).getFormattedMessage(), containsString("Exception:"));
+                    assertThat(logs.get(2).getThrowableProxy(), is(notNullValue()));
+                    assertThat(logs.get(2).getThrowableProxy().getClassName(), is("org.springframework.web.client.HttpClientErrorException"));
+                    assertThat(logs.get(2).getThrowableProxy().getMessage(), is("400 BAD_REQUEST"));
+                }
+        );
+    }
+
+    private ProceedingJoinPoint createJoinPoint(Class<Void> methodReturnType) throws Throwable {
+        return createJoinPoint(methodReturnType, (Void)null);
+    }
+
+    private <T> ProceedingJoinPoint createJoinPoint(Class<T> methodReturnType, T returnValue) throws Throwable {
+        return createJoinPoint(methodReturnType, returnValue, null);
+    }
+
+    private <T> ProceedingJoinPoint createJoinPoint(Exception exception) throws Throwable {
+        return createJoinPoint(void.class, exception);
+    }
+
+    private <T> ProceedingJoinPoint createJoinPoint(Class<T> methodReturnType, Exception exception) throws Throwable {
+        return createJoinPoint(methodReturnType, null, exception);
+    }
+
+    private <T> ProceedingJoinPoint createJoinPoint(Class<T> methodReturnType, T returnValue, Exception exception) throws Throwable {
+        final ProceedingJoinPoint joinPoint = Mockito.mock(ProceedingJoinPoint.class);
+        final MethodSignature methodSignature = Mockito.mock(MethodSignature.class);
+
+        when(joinPoint.getSignature()).thenReturn(methodSignature);
+
+        if (exception != null) {
+            when(joinPoint.proceed()).thenThrow(exception);
+        } else {
+            when(joinPoint.proceed()).thenReturn(returnValue);
+        }
+        when(joinPoint.getTarget()).thenReturn(new TestTarget());
+        when(joinPoint.getArgs()).thenReturn(new Object[] { TestData.ARG1, TestData.ARG2 });
+
+        when(methodSignature.getDeclaringType()).thenReturn(TestTarget.class);
+        when(methodSignature.getName()).thenReturn(TestData.METHOD);
+        when(methodSignature.getMethod()).thenReturn(TestTarget.class.getMethod(TestData.METHOD, String.class, String.class));
+        when(methodSignature.getReturnType()).thenReturn(methodReturnType);
+
+        return joinPoint;
+    }
+
+    private static RestControllerLogger createLogger(boolean includeCorrelationIdInLogs) {
+        return includeCorrelationIdInLogs ? new RestControllerLogger() : new RestControllerLogger(false);
     }
 
     private static class TestTarget {

--- a/src/test/java/com/spt/development/logging/spring/ServiceLoggerTest.java
+++ b/src/test/java/com/spt/development/logging/spring/ServiceLoggerTest.java
@@ -1,65 +1,183 @@
 package com.spt.development.logging.spring;
 
+import ch.qos.logback.classic.Level;
+import com.spt.development.cid.CorrelationId;
 import com.spt.development.logging.NoLogging;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
+import static com.spt.development.test.LogbackUtil.verifyLogging;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 class ServiceLoggerTest {
     private interface TestData {
+        String CORRELATION_ID = "7db425f7-ca20-4f95-a97b-7f0c95c92c9a";
         String RESULT = "Success!";
         String METHOD = "test";
         String ARG1 = "TestArg";
         String ARG2 = "TestArg2";
     }
 
-    @Test
-    void log_joinPointWithReturnValue_shouldReturnJoinPointResult() throws Throwable {
-        final ProceedingJoinPoint joinPoint = Mockito.mock(ProceedingJoinPoint.class);
-        final MethodSignature methodSignature = Mockito.mock(MethodSignature.class);
+    @BeforeEach
+    void setUp() {
+        CorrelationId.set(TestData.CORRELATION_ID);
+    }
 
-        when(joinPoint.getSignature()).thenReturn(methodSignature);
-        when(joinPoint.proceed()).thenReturn(TestData.RESULT);
-        when(joinPoint.getTarget()).thenReturn(new TestTarget());
-        when(joinPoint.getArgs()).thenReturn(new Object[] { TestData.ARG1, TestData.ARG2 });
-
-        when(methodSignature.getDeclaringType()).thenReturn(TestTarget.class);
-        when(methodSignature.getName()).thenReturn(TestData.METHOD);
-        when(methodSignature.getMethod()).thenReturn(TestTarget.class.getMethod(TestData.METHOD, String.class, String.class));
-        when(methodSignature.getReturnType()).thenReturn(String.class);
-
-        final Object result = createLogger().log(joinPoint);
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void log_joinPointWithReturnValue_shouldReturnJoinPointResult(boolean includeCorrelationIdInLogs) throws Throwable {
+        final Object result = createLogger(includeCorrelationIdInLogs).log(createJoinPoint(String.class, TestData.RESULT));
 
         assertThat(result, is(TestData.RESULT));
     }
 
     @Test
-    void log_joinPointWithVoidReturnType_shouldReturnNull() throws Throwable {
+    void log_joinPointWithReturnValue_shouldLogStartAndEndOfMethodWithoutCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(false).log(createJoinPoint(String.class, TestData.RESULT));
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(0).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.TRACE));
+                    assertThat(logs.get(1).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test Returned: " + TestData.RESULT));
+                }
+        );
+    }
+
+    @Test
+    void log_joinPointWithReturnValue_shouldLogStartAndEndOfMethodWithCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(true).log(createJoinPoint(String.class, TestData.RESULT));
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(0).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.TRACE));
+                    assertThat(logs.get(1).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test Returned: " + TestData.RESULT));
+                }
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void log_joinPointWithVoidReturnType_shouldReturnNull(boolean includeCorrelationIdInLogs) throws Throwable {
+        final Object result = createLogger(includeCorrelationIdInLogs).log(createJoinPoint(void.class));
+
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    void log_joinPointWithVoidReturnValue_shouldLogStartAndEndOfMethodWithoutCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(false).log(createJoinPoint(void.class));
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(0).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(1).getFormattedMessage(), not(startsWith("[" + TestData.CORRELATION_ID + "]")));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test - complete"));
+                }
+        );
+    }
+
+    @Test
+    void log_joinPointWithVoidReturnValue_shouldLogStartAndEndOfMethodWithCorrelationId() {
+        verifyLogging(
+                TestTarget.class,
+                () -> {
+                    try {
+                        return createLogger(true).log(createJoinPoint(void.class));
+                    } catch (Throwable t) {
+                        throw new RuntimeException(t);
+                    }
+                },
+                (logs) -> {
+                    assertThat(logs, is(notNullValue()));
+                    assertThat(logs.size(), is(2));
+
+                    assertThat(logs.get(0).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(0).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(0).getFormattedMessage(), containsString("TestTarget.test('TestArg', ******"));
+
+                    assertThat(logs.get(1).getLevel(), is(Level.DEBUG));
+                    assertThat(logs.get(1).getFormattedMessage(), startsWith("[" + TestData.CORRELATION_ID + "]"));
+                    assertThat(logs.get(1).getFormattedMessage(), containsString("TestTarget.test - complete"));
+                }
+        );
+    }
+
+    private ProceedingJoinPoint createJoinPoint(Class<Void> methodReturnType) throws Throwable {
+        return createJoinPoint(methodReturnType, null);
+    }
+
+    private <T> ProceedingJoinPoint createJoinPoint(Class<T> methodReturnType, T returnValue) throws Throwable {
         final ProceedingJoinPoint joinPoint = Mockito.mock(ProceedingJoinPoint.class);
         final MethodSignature methodSignature = Mockito.mock(MethodSignature.class);
 
         when(joinPoint.getSignature()).thenReturn(methodSignature);
+        when(joinPoint.proceed()).thenReturn(returnValue);
         when(joinPoint.getTarget()).thenReturn(new TestTarget());
         when(joinPoint.getArgs()).thenReturn(new Object[] { TestData.ARG1, TestData.ARG2 });
 
         when(methodSignature.getDeclaringType()).thenReturn(TestTarget.class);
         when(methodSignature.getName()).thenReturn(TestData.METHOD);
         when(methodSignature.getMethod()).thenReturn(TestTarget.class.getMethod(TestData.METHOD, String.class, String.class));
-        when(methodSignature.getReturnType()).thenReturn(void.class);
+        when(methodSignature.getReturnType()).thenReturn(methodReturnType);
 
-        final Object result = createLogger().log(joinPoint);
-
-        assertThat(result, is(nullValue()));
+        return joinPoint;
     }
 
-    private ServiceLogger createLogger() {
-        return new ServiceLogger();
+    private ServiceLogger createLogger(boolean includeCorrelationIdInLogs) {
+        return includeCorrelationIdInLogs ? new ServiceLogger() : new ServiceLogger(false);
     }
 
     private static class TestTarget {


### PR DESCRIPTION
…e generated log statements, on and off and switched mutation testing back on.